### PR TITLE
Add ISO 2768 tolerance support with identification and coverage tests

### DIFF
--- a/src/DeviationTolerance.ts
+++ b/src/DeviationTolerance.ts
@@ -1,0 +1,47 @@
+import {Tolerance} from "./Tolerance";
+
+/**
+ * Represents a tolerance with separate upper and lower bounds. For example,
+ * an upper bound of 0.2 mm and a lower bound of -0.1 mm.
+ */
+export class DeviationTolerance implements Tolerance {
+
+    /**
+     * Private constructor to enforce the use of the factory method.
+     *
+     * @param upper the upper bound of the tolerance in millimetres.
+     * @param lower the lower bound of the tolerance in millimetres.
+     * @throws Error if either the upper or the lower bound is not finite.
+     * @throws Error if the upper bound is less than the lower bound.
+     */
+    private constructor(private readonly upper: number, private readonly lower: number) {
+        // The fields are assigned via parameter properties.
+        // Guard against invalid inputs.
+        if (!Number.isFinite(upper) || !Number.isFinite(lower)) {
+            throw new Error("Both upper and lower bounds must be finite numbers.");
+        }
+        // Ensure that the upper bound is greater than or equal to the lower bound.
+        if (upper < lower) {
+            throw new Error("Upper bound must be greater than or equal to lower bound.");
+        }
+    }
+
+    /**
+     * Static factory method for constructing a deviation tolerance from upper
+     * and lower bounds in millimetres.
+     *
+     * @param upper the upper bound of the tolerance in millimetres.
+     * @param lower the lower bound of the tolerance in millimetres.
+     */
+    static fromUpperAndLowerBoundsInMillimetres(upper: number, lower: number): DeviationTolerance {
+        return new DeviationTolerance(upper, lower);
+    }
+
+    getUpper(): number {
+        return this.upper;
+    }
+
+    getLower(): number {
+        return this.lower;
+    }
+}

--- a/src/Dimension.ts
+++ b/src/Dimension.ts
@@ -25,4 +25,20 @@ export class Dimension {
     getMillimetres(): number {
         return this.mm;
     }
+
+    greaterThan(other: Dimension): boolean {
+        return this.mm > other.getMillimetres();
+    }
+
+    greaterThanOrEqual(other: Dimension): boolean {
+        return this.mm >= other.getMillimetres();
+    }
+
+    lessThan(other: Dimension): boolean {
+        return this.mm < other.getMillimetres();
+    }
+
+    lessThanOrEqual(other: Dimension): boolean {
+        return this.mm <= other.getMillimetres();
+    }
 }

--- a/src/Dimension.ts
+++ b/src/Dimension.ts
@@ -1,0 +1,28 @@
+/**
+ * Dimension is a class representing a dimension in a technical drawing, in
+ * millimetres.
+ */
+export class Dimension {
+
+    /**
+     * Private constructor to enforce the use of the factory method.
+     *
+     * @param mm the millimetres of the dimension.
+     */
+    private constructor(private readonly mm: number) {
+        // The field is assigned via a parameter property.
+    }
+
+    /**
+     * Static factory method for constructing a Dimension from millimetres.
+     *
+     * @param mm the millimetres of the dimension.
+     */
+    static fromMillimetres(mm: number): Dimension {
+        return new Dimension(mm);
+    }
+
+    getMillimetres(): number {
+        return this.mm;
+    }
+}

--- a/src/DimensionRange.ts
+++ b/src/DimensionRange.ts
@@ -1,0 +1,82 @@
+import {Dimension} from './Dimension';
+
+/**
+ * Represents a dimensional range with a lower and upper bound. It is used to
+ * check if a dimension is within the range. However, since that check is
+ * different depending on the context, a strategy is used to determine that,
+ * so that it's straightforward to adjust.
+ */
+export class DimensionRange {
+
+    /**
+     * Private constructor to enforce the use of the static factory methods.
+     *
+     * @param lower the lower-bound dimension of the range.
+     * @param upper the upper-bound dimension of the range.
+     * @param strategy the containment strategy for checking if a dimension is
+     *                 within the range.
+     */
+    private constructor(private readonly lower: Dimension,
+                        private readonly upper: Dimension,
+                        private readonly strategy: ContainmentStrategy) {
+        // The fields are assigned via parameter properties.
+    }
+
+    /**
+     * Creates a DimensionRange with both lower and upper bounds inclusive.
+     * Dimensions equal to the lower or upper bound are considered within the
+     * range.
+     *
+     * @param lower the inclusive lower-bound dimension of the range.
+     * @param upper the inclusive upper-bound dimension of the range.
+     */
+    static fromAndUpTo(lower: Dimension, upper: Dimension): DimensionRange {
+        return new DimensionRange(lower, upper, new LowerBoundInclusiveContainmentStrategy());
+    }
+
+    /**
+     * Creates a DimensionRange with an exclusive lower bound and inclusive
+     * upper bound. Dimensions greater than the lower bound and equal to or less
+     * than the upper bound are considered within the range.
+     *
+     * @param lower the exclusive lower-bound dimension of the range.
+     * @param upper the inclusive upper-bound dimension of the range.
+     */
+    static fromOverAndUpTo(lower: Dimension, upper: Dimension): DimensionRange {
+        return new DimensionRange(lower, upper, new LowerBoundExclusiveContainmentStrategy());
+    }
+
+    containsDimension(dimension: Dimension): boolean {
+        return this.strategy.containsDimension(dimension, this.lower, this.upper);
+    }
+}
+
+/**
+ * Interface for containment strategies used to determine if a dimension is
+ * within a range of lower and upper dimensional bounds.
+ */
+interface ContainmentStrategy {
+    containsDimension(dimension: Dimension, from: Dimension, to: Dimension): boolean;
+}
+
+/**
+ * Containment strategy where the lower and upper bound is inclusive. A
+ * dimension is within the range if it is greater than or equal to the lower
+ * bound and less than or equal to the upper bound.
+ */
+class LowerBoundInclusiveContainmentStrategy implements ContainmentStrategy {
+    containsDimension(dimension: Dimension, lower: Dimension, upper: Dimension): boolean {
+        return dimension.greaterThanOrEqual(lower) && dimension.lessThanOrEqual(upper);
+    }
+}
+
+/**
+ * Containment strategy where the lower bound is exclusive and the upper bound
+ * is inclusive. A dimension is within the range if it is greater than the lower
+ * bound and less than or equal to the upper bound.
+ */
+class LowerBoundExclusiveContainmentStrategy implements ContainmentStrategy {
+    containsDimension(dimension: Dimension, lower: Dimension, upper: Dimension): boolean {
+        return dimension.greaterThan(lower) && dimension.lessThanOrEqual(upper);
+    }
+}

--- a/src/DimensionWithTolerance.ts
+++ b/src/DimensionWithTolerance.ts
@@ -1,3 +1,35 @@
+import {Dimension} from "./Dimension";
+import {Tolerance} from "./Tolerance";
+
+/**
+ * Represents a dimension with a tolerance associated with it.
+ */
 export class DimensionWithTolerance {
-    // To be implemented.
+
+    /**
+     * Private constructor to enforce the use of the factory method.
+     */
+    private constructor(private readonly dimension: Dimension,
+                        private readonly tolerance: Tolerance) {
+        // The fields are assigned via parameter properties.
+    }
+
+    /**
+     * Static factory method for constructing a DimensionWithTolerance from a
+     * dimension and tolerance.
+     *
+     * @param dimension the dimension.
+     * @param tolerance the associated tolerance.
+     */
+    static fromDimensionAndTolerance(dimension: Dimension, tolerance: Tolerance): DimensionWithTolerance {
+        return new DimensionWithTolerance(dimension, tolerance);
+    }
+
+    getDimension(): Dimension {
+        return this.dimension;
+    }
+
+    getTolerance(): Tolerance {
+        return this.tolerance;
+    }
 }

--- a/src/DimensionWithTolerance.ts
+++ b/src/DimensionWithTolerance.ts
@@ -1,0 +1,3 @@
+export class DimensionWithTolerance {
+    // To be implemented.
+}

--- a/src/Iso2768ToleranceStandard.ts
+++ b/src/Iso2768ToleranceStandard.ts
@@ -1,0 +1,39 @@
+import {ToleranceStandard} from "./ToleranceStandard";
+
+/**
+ * Represents the four possible tolerance classes for ISO 2768-1:1989:
+ * - f (fine)
+ * - m (medium)
+ * - c (coarse)
+ * - v (very coarse)
+ */
+export type Iso2768ToleranceClass = 'f' | 'm' | 'c' | 'v';
+
+/**
+ * Represents the ISO 2768-1:1989 tolerance standard.
+ */
+export class Iso2768ToleranceStandard implements ToleranceStandard {
+
+    /**
+     * Private constructor to enforce the use of the static factory method.
+     *
+     * @param toleranceClass the tolerance class of the standard.
+     */
+    private constructor(private readonly toleranceClass: Iso2768ToleranceClass) {
+        // The field is assigned via a parameter property.
+    }
+
+    /**
+     * Static factory method for constructing an ISO 2768-1:1989 tolerance
+     * standard from an ISO 2768-1:1989 tolerance class.
+     *
+     * @param toleranceClass the tolerance class of the standard.
+     */
+    static fromToleranceClass(toleranceClass: Iso2768ToleranceClass): Iso2768ToleranceStandard {
+        return new Iso2768ToleranceStandard(toleranceClass);
+    }
+
+    getToleranceClass(): Iso2768ToleranceClass {
+        return this.toleranceClass;
+    }
+}

--- a/src/Iso2768ToleranceStandardIdentifier.ts
+++ b/src/Iso2768ToleranceStandardIdentifier.ts
@@ -1,0 +1,13 @@
+import {DimensionWithTolerance} from "./DimensionWithTolerance";
+import {ToleranceStandard} from "./ToleranceStandard";
+import {ToleranceStandardIdentifier} from "./ToleranceStandardIdentifier";
+
+/**
+ * Tolerance standard identifier for ISO 2768-1:1989.
+ */
+export class Iso2768ToleranceStandardIdentifier implements ToleranceStandardIdentifier {
+
+    identifyToleranceStandard(dimensionWithTolerance: DimensionWithTolerance): ToleranceStandard | null {
+        return null;
+    }
+}

--- a/src/Iso2768ToleranceStandardIdentifier.ts
+++ b/src/Iso2768ToleranceStandardIdentifier.ts
@@ -1,13 +1,60 @@
+import {ToleranceStandardIdentifier} from "./ToleranceStandardIdentifier";
+import {Dimension} from "./Dimension";
+import {Tolerance} from "./Tolerance";
 import {DimensionWithTolerance} from "./DimensionWithTolerance";
 import {ToleranceStandard} from "./ToleranceStandard";
-import {ToleranceStandardIdentifier} from "./ToleranceStandardIdentifier";
+import {ToleranceCoverageChecker} from "./ToleranceCoverageChecker";
+import {Iso2768ToleranceStandard} from "./Iso2768ToleranceStandard";
+import {ISO_2768_TABLE} from "./iso-2768-table";
 
 /**
  * Tolerance standard identifier for ISO 2768-1:1989.
  */
 export class Iso2768ToleranceStandardIdentifier implements ToleranceStandardIdentifier {
 
+    /**
+     * Identifies the widest appropriate ISO 2768-1:1989 tolerance standard for a dimension with a tolerance.
+     *
+     * @param dimensionWithTolerance the dimension with its associated tolerance to be identified.
+     */
     identifyToleranceStandard(dimensionWithTolerance: DimensionWithTolerance): ToleranceStandard | null {
+        const dimension: Dimension = dimensionWithTolerance.getDimension();
+        const tolerance: Tolerance = dimensionWithTolerance.getTolerance();
+
+        for (const range of ISO_2768_TABLE) {
+            // If the dimension is not within the nominal size range, skip to the next range.
+            if (!range.nominalSizeRange.containsDimension(dimension)) {
+                continue;
+            }
+
+            // Mapping tolerance classes to associated tolerances so that we can iterate over them readably in the next
+            // step. The order of the tolerance classes is important. By starting with the very coarse tolerance and
+            // going to the fine tolerance, it ensures that the widest appropriate tolerance class is matched.
+            const toleranceClasses: Array<{
+                toleranceClass: 'f' | 'm' | 'c' | 'v',
+                associatedTolerance: Tolerance | null
+            }> = [
+                {toleranceClass: 'v', associatedTolerance: range.veryCoarseTolerance},
+                {toleranceClass: 'c', associatedTolerance: range.coarseTolerance},
+                {toleranceClass: 'm', associatedTolerance: range.mediumTolerance},
+                {toleranceClass: 'f', associatedTolerance: range.fineTolerance}
+            ];
+
+            // Iterating over the tolerance classes to find the widest one that covers the tolerance.
+            for (const {toleranceClass, associatedTolerance} of toleranceClasses) {
+                // The associated tolerance may be null if the tolerance class
+                // is undefined for the current range. Skip in that case.
+                if (associatedTolerance === null) {
+                    continue;
+                }
+                // Check if the tolerance is covered by the tolerance of the tolerance class, return that class if so.
+                if (ToleranceCoverageChecker.isToleranceCovered(tolerance, associatedTolerance)) {
+                    return Iso2768ToleranceStandard.fromToleranceClass(toleranceClass);
+                }
+            }
+        }
+
+        // If no matching tolerance standard and class is found, return null indicating that none applies.
         return null;
     }
 }

--- a/src/SymmetricalTolerance.ts
+++ b/src/SymmetricalTolerance.ts
@@ -1,0 +1,40 @@
+import {Tolerance} from "./Tolerance";
+
+/**
+ * Represents a tolerance with equal upper and lower bounds, but opposite
+ * signs. For example, ±0.2 mm.
+ */
+export class SymmetricalTolerance implements Tolerance {
+
+    /**
+     * Private constructor to enforce the use of the factory method.
+     *
+     * @param mm the symmetrical tolerance in millimetres.
+     */
+    private constructor(private readonly mm: number) {
+        // The field is assigned via a parameter property.
+    }
+
+    /**
+     * Static factory method for constructing a symmetrical tolerance from
+     * millimetres.
+     *
+     * @param mm the symmetrical upper and lower tolerance in millimetres.
+     * @throws Error if mm is not a finite number, for example, NaN or Infinity.
+     */
+    static fromMillimetres(mm: number): SymmetricalTolerance {
+        if (!Number.isFinite(mm)) {
+            throw new Error("Tolerance must be a finite number.");
+        }
+        // Using absolute to ensure the tolerance is always positive.
+        return new SymmetricalTolerance(Math.abs(mm));
+    }
+
+    getUpper(): number {
+        return this.mm;
+    }
+
+    getLower(): number {
+        return -this.mm;
+    }
+}

--- a/src/Tolerance.ts
+++ b/src/Tolerance.ts
@@ -1,0 +1,9 @@
+/**
+ * Represents a tolerance with upper and lower bounds. Implementations can
+ * define different types of tolerances, such as symmetrical or deviation
+ * tolerances.
+ */
+export interface Tolerance {
+    getUpper(): number;
+    getLower(): number;
+}

--- a/src/ToleranceCoverageChecker.ts
+++ b/src/ToleranceCoverageChecker.ts
@@ -1,0 +1,25 @@
+import {Tolerance} from "./Tolerance";
+
+/**
+ * Utility class that provides a method to check if one tolerance covers another.
+ */
+export class ToleranceCoverageChecker {
+
+    /**
+     * Checks if a tolerance is covered by another tolerance.
+     *
+     * A tolerance is considered covered if it's wider than or equal to the other
+     * tolerance. Meaning its upper bound is greater than or equal to the other
+     * tolerance's upper bound, and its lower bound is less than or equal to the
+     * other tolerance's lower bound.
+     *
+     * For example, a tolerance of ±0.2 mm covers a tolerance of ±0.2 mm and ±0.3,
+     * but not a tolerance of ±0.1 mm.
+     *
+     * @param candidate the tolerance being checked for coverage.
+     * @param cover the tolerance that may cover the candidate tolerance.
+     */
+    static isToleranceCovered(candidate: Tolerance, cover: Tolerance): boolean {
+        return candidate.getUpper() >= cover.getUpper() && candidate.getLower() <= cover.getLower();
+    }
+}

--- a/src/ToleranceStandard.ts
+++ b/src/ToleranceStandard.ts
@@ -1,0 +1,6 @@
+/**
+ * Tolerance Standard is mostly a marker interface to represent standards such
+ * as ISO 2768-1:1989 and ISO 286-1:2010.
+ */
+export interface ToleranceStandard {
+}

--- a/src/ToleranceStandardIdentifier.ts
+++ b/src/ToleranceStandardIdentifier.ts
@@ -1,0 +1,6 @@
+import {DimensionWithTolerance} from "./DimensionWithTolerance";
+import {ToleranceStandard} from "./ToleranceStandard";
+
+export interface ToleranceStandardIdentifier {
+    identifyToleranceStandard(dimensionWithTolerance: DimensionWithTolerance): ToleranceStandard | null;
+}

--- a/src/ToleranceStandardIdentifier.ts
+++ b/src/ToleranceStandardIdentifier.ts
@@ -1,6 +1,10 @@
 import {DimensionWithTolerance} from "./DimensionWithTolerance";
 import {ToleranceStandard} from "./ToleranceStandard";
 
+/**
+ * Tolerance Standard Identifier is an interface for identifiers for standards
+ * such as ISO 2768-1:1989 and ISO 286-1:2010.
+ */
 export interface ToleranceStandardIdentifier {
     identifyToleranceStandard(dimensionWithTolerance: DimensionWithTolerance): ToleranceStandard | null;
 }

--- a/src/iso-2768-table.ts
+++ b/src/iso-2768-table.ts
@@ -1,0 +1,106 @@
+import {DimensionRange} from "./DimensionRange";
+import {Tolerance} from "./Tolerance";
+import {SymmetricalTolerance} from "./SymmetricalTolerance";
+import {Dimension} from "./Dimension";
+
+/**
+ * In ISO 2768-1:1989, the tolerances for linear dimensions are defined in ranges.
+ * Each range has a nominal size (dimension range) and associated tolerances for
+ * the classes.
+ *
+ * This is the representation of a range.
+ */
+export interface Iso2768DimensionRangeAndTolerances {
+    nominalSizeRange: DimensionRange;
+    fineTolerance: Tolerance | null;  // Fine tolerance may not be defined for all ranges.
+    mediumTolerance: Tolerance;
+    coarseTolerance: Tolerance;
+    veryCoarseTolerance: Tolerance | null;  // Very coarse tolerance may not be defined for all ranges.
+}
+
+/**
+ * A table for the linear dimensions in ISO 2768-1:1989. It defines the nominal
+ * size ranges and the associated tolerances for each class.
+ */
+export const ISO_2768_TABLE: Iso2768DimensionRangeAndTolerances[] = [
+    {
+        nominalSizeRange: DimensionRange.fromAndUpTo(
+            Dimension.fromMillimetres(0.5),
+            Dimension.fromMillimetres(3)
+        ),
+        fineTolerance: SymmetricalTolerance.fromMillimetres(0.05),
+        mediumTolerance: SymmetricalTolerance.fromMillimetres(0.1),
+        coarseTolerance: SymmetricalTolerance.fromMillimetres(0.2),
+        veryCoarseTolerance: null  // No very coarse tolerance for this range
+    },
+    {
+        nominalSizeRange: DimensionRange.fromOverAndUpTo(
+            Dimension.fromMillimetres(3),
+            Dimension.fromMillimetres(6)
+        ),
+        fineTolerance: SymmetricalTolerance.fromMillimetres(0.05),
+        mediumTolerance: SymmetricalTolerance.fromMillimetres(0.1),
+        coarseTolerance: SymmetricalTolerance.fromMillimetres(0.3),
+        veryCoarseTolerance: SymmetricalTolerance.fromMillimetres(0.5)
+    },
+    {
+        nominalSizeRange: DimensionRange.fromOverAndUpTo(
+            Dimension.fromMillimetres(6),
+            Dimension.fromMillimetres(30)
+        ),
+        fineTolerance: SymmetricalTolerance.fromMillimetres(0.1),
+        mediumTolerance: SymmetricalTolerance.fromMillimetres(0.2),
+        coarseTolerance: SymmetricalTolerance.fromMillimetres(0.5),
+        veryCoarseTolerance: SymmetricalTolerance.fromMillimetres(1.0)
+    },
+    {
+        nominalSizeRange: DimensionRange.fromOverAndUpTo(
+            Dimension.fromMillimetres(30),
+            Dimension.fromMillimetres(120)
+        ),
+        fineTolerance: SymmetricalTolerance.fromMillimetres(0.15),
+        mediumTolerance: SymmetricalTolerance.fromMillimetres(0.3),
+        coarseTolerance: SymmetricalTolerance.fromMillimetres(0.8),
+        veryCoarseTolerance: SymmetricalTolerance.fromMillimetres(1.5)
+    },
+    {
+        nominalSizeRange: DimensionRange.fromOverAndUpTo(
+            Dimension.fromMillimetres(120),
+            Dimension.fromMillimetres(400)
+        ),
+        fineTolerance: SymmetricalTolerance.fromMillimetres(0.2),
+        mediumTolerance: SymmetricalTolerance.fromMillimetres(0.5),
+        coarseTolerance: SymmetricalTolerance.fromMillimetres(1.2),
+        veryCoarseTolerance: SymmetricalTolerance.fromMillimetres(2.5)
+    },
+    {
+        nominalSizeRange: DimensionRange.fromOverAndUpTo(
+            Dimension.fromMillimetres(400),
+            Dimension.fromMillimetres(1000)
+        ),
+        fineTolerance: SymmetricalTolerance.fromMillimetres(0.3),
+        mediumTolerance: SymmetricalTolerance.fromMillimetres(0.8),
+        coarseTolerance: SymmetricalTolerance.fromMillimetres(2.0),
+        veryCoarseTolerance: SymmetricalTolerance.fromMillimetres(4.0)
+    },
+    {
+        nominalSizeRange: DimensionRange.fromOverAndUpTo(
+            Dimension.fromMillimetres(1000),
+            Dimension.fromMillimetres(2000)
+        ),
+        fineTolerance: SymmetricalTolerance.fromMillimetres(0.5),
+        mediumTolerance: SymmetricalTolerance.fromMillimetres(1.2),
+        coarseTolerance: SymmetricalTolerance.fromMillimetres(3.0),
+        veryCoarseTolerance: SymmetricalTolerance.fromMillimetres(6.0)
+    },
+    {
+        nominalSizeRange: DimensionRange.fromOverAndUpTo(
+            Dimension.fromMillimetres(2000),
+            Dimension.fromMillimetres(4000)
+        ),
+        fineTolerance: null, // No fine tolerance for this range
+        mediumTolerance: SymmetricalTolerance.fromMillimetres(2.0),
+        coarseTolerance: SymmetricalTolerance.fromMillimetres(4.0),
+        veryCoarseTolerance: SymmetricalTolerance.fromMillimetres(8.0)
+    }
+];

--- a/tests/DeviationTolerance.test.ts
+++ b/tests/DeviationTolerance.test.ts
@@ -1,0 +1,49 @@
+import {DeviationTolerance} from "../src/DeviationTolerance";
+
+describe('Deviation Tolerance', () => {
+
+    describe('When constructing with factory method', () => {
+
+        test('Upper bound getter should return correct value', () => {
+            const upper = 0.2;
+            const lower = -0.1;
+            const tolerance = DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(upper, lower);
+            expect(tolerance.getUpper()).toBe(upper);
+        });
+
+        test('Lower bound getter should return correct value', () => {
+            const upper = 0.2;
+            const lower = -0.1;
+            const tolerance = DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(upper, lower);
+            expect(tolerance.getLower()).toBe(lower);
+        });
+
+        test('Should throw error if upper bound is an infinite number', () => {
+            expect(() => DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(Infinity, -0.1)).toThrow();
+        });
+
+        test('Should throw error if upper bound is NaN', () => {
+            expect(() => DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(NaN, -0.1)).toThrow();
+        });
+
+        test('Should throw error if lower bound is an infinite number', () => {
+            expect(() => DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, Infinity)).toThrow();
+        });
+
+        test('Should throw error if lower bound is NaN', () => {
+            expect(() => DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, NaN)).toThrow();
+        });
+
+        test('Should not throw error if upper bound is greater than lower bound', () => {
+            expect(() => DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, -0.1)).not.toThrow();
+        });
+
+        test('Should not throw error if upper bound is equal to lower bound', () => {
+            expect(() => DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, 0.1)).not.toThrow();
+        });
+
+        test('Should throw error if upper bound is smaller than lower bound', () => {
+            expect(() => DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(-0.1, 0.1)).toThrow();
+        });
+    });
+});

--- a/tests/Dimension.test.ts
+++ b/tests/Dimension.test.ts
@@ -1,0 +1,29 @@
+import {Dimension} from "../src/Dimension";
+
+describe('Dimension', () => {
+
+    test('Should construct from and return zero millimetres', () => {
+        const dimension: Dimension = Dimension.fromMillimetres(0.0);
+        expect(dimension.getMillimetres()).toBe(0.0);
+    });
+
+    test('Should construct from and return positive millimetres', () => {
+        const dimension: Dimension = Dimension.fromMillimetres(1.0);
+        expect(dimension.getMillimetres()).toBe(1.0);
+    });
+
+    test('Should construct from and return positive decimal millimetres', () => {
+        const dimension: Dimension = Dimension.fromMillimetres(1.5);
+        expect(dimension.getMillimetres()).toBe(1.5);
+    });
+
+    test('Should construct from and return negative millimetres', () => {
+        const dimension: Dimension = Dimension.fromMillimetres(-1.0);
+        expect(dimension.getMillimetres()).toBe(-1.0);
+    });
+
+    test('Should construct from and return negative decimal millimetres', () => {
+        const dimension: Dimension = Dimension.fromMillimetres(-1.5);
+        expect(dimension.getMillimetres()).toBe(-1.5);
+    });
+});

--- a/tests/Dimension.test.ts
+++ b/tests/Dimension.test.ts
@@ -26,4 +26,84 @@ describe('Dimension', () => {
         const dimension: Dimension = Dimension.fromMillimetres(-1.5);
         expect(dimension.getMillimetres()).toBe(-1.5);
     });
+
+    describe('Greater-than comparison', () => {
+        test('Should return false for a dimension equal to another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(1.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(1.0);
+            expect(dimension1.lessThan(dimension2)).toBe(false);
+        });
+
+        test('Should return false for a dimension less than another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(1.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(2.0);
+            expect(dimension1.lessThan(dimension2)).toBe(true);
+        });
+
+        test('Should return true for a dimension greater than another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(2.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(1.0);
+            expect(dimension1.lessThan(dimension2)).toBe(false);
+        });
+    });
+
+    describe('Greater-than-or-equal comparison', () => {
+        test('Should return true for a dimension equal to another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(1.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(1.0);
+            expect(dimension1.lessThan(dimension2)).toBe(false);
+        });
+
+        test('Should return false for a dimension less than another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(1.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(2.0);
+            expect(dimension1.lessThan(dimension2)).toBe(true);
+        });
+
+        test('Should return true for a dimension greater than another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(2.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(1.0);
+            expect(dimension1.lessThan(dimension2)).toBe(false);
+        });
+    });
+
+    describe('Less-than comparison', () => {
+        test('Should return false for a dimension equal to another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(1.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(1.0);
+            expect(dimension1.lessThan(dimension2)).toBe(false);
+        });
+
+        test('Should return true for a dimension less than another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(1.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(2.0);
+            expect(dimension1.lessThan(dimension2)).toBe(true);
+        });
+
+        test('Should return false for a dimension greater than another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(2.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(1.0);
+            expect(dimension1.lessThan(dimension2)).toBe(false);
+        });
+    });
+
+    describe('Less-than-or-equal comparison', () => {
+        test('Should return true for a dimension equal to another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(1.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(1.0);
+            expect(dimension1.lessThan(dimension2)).toBe(false);
+        });
+
+        test('Should return true for a dimension less than another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(1.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(2.0);
+            expect(dimension1.lessThan(dimension2)).toBe(true);
+        });
+
+        test('Should return false for a dimension greater than another', () => {
+            const dimension1: Dimension = Dimension.fromMillimetres(2.0);
+            const dimension2: Dimension = Dimension.fromMillimetres(1.0);
+            expect(dimension1.lessThan(dimension2)).toBe(false);
+        });
+    });
 });

--- a/tests/DimensionRange.test.ts
+++ b/tests/DimensionRange.test.ts
@@ -1,0 +1,101 @@
+import {DimensionRange} from "../src/DimensionRange";
+import {Dimension} from "../src/Dimension";
+
+describe('DimensionRange', () => {
+
+    describe('from-and-up-to', () => {
+
+        test('Should not contain a dimension less than the lower bound', () => {
+            const range = DimensionRange.fromAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(0.5);
+            expect(range.containsDimension(dimension)).toBe(false);
+        });
+
+        test('Should contain a dimension equal to the lower bound', () => {
+            const range = DimensionRange.fromAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(1.0);
+            expect(range.containsDimension(dimension)).toBe(true);
+        });
+
+        test('Should contain a dimension between the lower bound and upper bound', () => {
+            const range = DimensionRange.fromAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(1.5);
+            expect(range.containsDimension(dimension)).toBe(true);
+        });
+
+        test('Should contain a dimension equal to the upper bound', () => {
+            const range = DimensionRange.fromAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(2.0);
+            expect(range.containsDimension(dimension)).toBe(true);
+        });
+
+        test('Should not contain a dimension greater than the upper bound', () => {
+            const range = DimensionRange.fromAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(2.5);
+            expect(range.containsDimension(dimension)).toBe(false);
+        });
+    });
+
+    describe('from-over-and-up-to', () => {
+
+        test('Should not contain a dimension less than the lower bound', () => {
+            const range = DimensionRange.fromOverAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(0.5);
+            expect(range.containsDimension(dimension)).toBe(false);
+        });
+
+        test('Should not contain a dimension equal to the lower bound', () => {
+            const range = DimensionRange.fromOverAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(1.0);
+            expect(range.containsDimension(dimension)).toBe(false);
+        });
+
+        test('Should contain a dimension between the lower bound and upper bound', () => {
+            const range = DimensionRange.fromOverAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(1.5);
+            expect(range.containsDimension(dimension)).toBe(true);
+        });
+
+        test('Should contain a dimension equal to the upper bound', () => {
+            const range = DimensionRange.fromOverAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(2.0);
+            expect(range.containsDimension(dimension)).toBe(true);
+        });
+
+        test('Should not contain a dimension greater than the upper bound', () => {
+            const range = DimensionRange.fromOverAndUpTo(
+                Dimension.fromMillimetres(1.0),
+                Dimension.fromMillimetres(2.0)
+            );
+            const dimension = Dimension.fromMillimetres(2.5);
+            expect(range.containsDimension(dimension)).toBe(false);
+        });
+    });
+});

--- a/tests/DimensionWithTolerance.test.ts
+++ b/tests/DimensionWithTolerance.test.ts
@@ -1,0 +1,23 @@
+import {Dimension} from "../src/Dimension";
+import {SymmetricalTolerance} from "../src/SymmetricalTolerance";
+import {DimensionWithTolerance} from "../src/DimensionWithTolerance";
+
+describe("Dimension With Tolerance", () => {
+
+    describe('When constructing with factory method', () => {
+
+        test('Dimension getter should return the dimension', () => {
+            const dimension: Dimension = Dimension.fromMillimetres(1.0);
+            const tolerance: SymmetricalTolerance = SymmetricalTolerance.fromMillimetres(0.0);  // The tolerance is irrelevant but needed for construction.
+            const dimensionWithTolerance: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(dimension, tolerance);
+            expect(dimensionWithTolerance.getDimension()).toBe(dimension);
+        });
+
+        test('Tolerance getter should return the tolerance', () => {
+            const dimension: Dimension = Dimension.fromMillimetres(0.0);  // The dimension is irrelevant but needed for construction.
+            const tolerance: SymmetricalTolerance = SymmetricalTolerance.fromMillimetres(0.2);
+            const dimensionWithTolerance: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(dimension, tolerance);
+            expect(dimensionWithTolerance.getTolerance()).toBe(tolerance);
+        });
+    });
+});

--- a/tests/Iso2768ToleranceStandard.test.ts
+++ b/tests/Iso2768ToleranceStandard.test.ts
@@ -1,0 +1,16 @@
+import {Iso2768ToleranceClass, Iso2768ToleranceStandard} from "../src/Iso2768ToleranceStandard";
+
+describe('ISO 2768 Tolerance Standard', () => {
+
+    describe('When constructing with factory method', () => {
+
+        const toleranceClasses: Iso2768ToleranceClass[] = ['f', 'm', 'c', 'v'];
+
+        toleranceClasses.forEach(toleranceClass => {
+            test(`Tolerance class getter should return tolerance class '${toleranceClass}'`, () => {
+                const toleranceStandard: Iso2768ToleranceStandard = Iso2768ToleranceStandard.fromToleranceClass(toleranceClass);
+                expect(toleranceStandard.getToleranceClass()).toBe(toleranceClass);
+            });
+        });
+    });
+});

--- a/tests/Iso2768ToleranceStandardIdentifier.test.ts
+++ b/tests/Iso2768ToleranceStandardIdentifier.test.ts
@@ -3,6 +3,7 @@ import {DimensionWithTolerance} from "../src/DimensionWithTolerance";
 import {Dimension} from "../src/Dimension";
 import {SymmetricalTolerance} from "../src/SymmetricalTolerance";
 import {ToleranceStandard} from "../src/ToleranceStandard";
+import {Iso2768ToleranceStandard} from "../src/Iso2768ToleranceStandard";
 
 describe('ISO 2768-1 Tolerance Standard Identifier', () => {
 
@@ -26,5 +27,64 @@ describe('ISO 2768-1 Tolerance Standard Identifier', () => {
             const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
             expect(result).toBeNull();
         })
+    });
+
+    // Use the tolerance table for linear dimensions in the ISO 2768-1:1989
+    // documentation as reference: docs/iso-2768-1-1989.md
+    const iso2768fTestGroups = [
+        {
+            // Dimensions that are the lowest in the nominal size range for fine tolerance.
+            type: 'Floor dimensions',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.05)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.05)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.1)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.15)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(0.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(0.3)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(0.5))
+                // No tolerance for fine for over 2000 up to 4000.
+            ]
+        },
+        {
+            // Dimensions that are the highest in the nominal size range for fine tolerance.
+            type: 'Ceiling dimensions',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.05)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.05)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(0.1)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(0.15)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(0.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(0.3)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(0.5))
+                // No tolerance for fine for over 2000 up to 4000.
+            ]
+        },
+        {
+            // Tolerances that are just below the medium tolerance class.
+            type: 'Ceiling tolerances',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1), SymmetricalTolerance.fromMillimetres(0.1 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(0.1 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(10), SymmetricalTolerance.fromMillimetres(0.2 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(50), SymmetricalTolerance.fromMillimetres(0.3 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(200), SymmetricalTolerance.fromMillimetres(0.5 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(800), SymmetricalTolerance.fromMillimetres(0.8 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(1.2 - 0.01))
+                // No tolerance for fine over 2000 up to 4000.
+            ]
+        }
+    ];
+
+    describe('ISO 2768-f tests', () => {
+        iso2768fTestGroups.forEach(group => {
+            describe(group.type, () => {
+                test.each(group.cases)(`should identify ISO 2768-f for %s`, (dimensionWithTolerance: DimensionWithTolerance) => {
+                        const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimensionWithTolerance);
+                        expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+                    }
+                );
+            });
+        });
     });
 });

--- a/tests/Iso2768ToleranceStandardIdentifier.test.ts
+++ b/tests/Iso2768ToleranceStandardIdentifier.test.ts
@@ -1,0 +1,30 @@
+import {Iso2768ToleranceStandardIdentifier} from "../src/Iso2768ToleranceStandardIdentifier";
+import {DimensionWithTolerance} from "../src/DimensionWithTolerance";
+import {Dimension} from "../src/Dimension";
+import {SymmetricalTolerance} from "../src/SymmetricalTolerance";
+import {ToleranceStandard} from "../src/ToleranceStandard";
+
+describe('ISO 2768-1 Tolerance Standard Identifier', () => {
+
+    const identifier: Iso2768ToleranceStandardIdentifier = new Iso2768ToleranceStandardIdentifier();
+
+    describe('With edge cases', () => {
+        test('Should not identify a tolerance standard for a dimension less than the nominal range', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(0.4),
+                SymmetricalTolerance.fromMillimetres(0.0)  // The tolerance is irrelevant in this case.
+            );
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toBeNull();
+        });
+
+        test('Should not identify a tolerance standard for a dimension greater than the nominal range', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(4001),
+                SymmetricalTolerance.fromMillimetres(0.0)  // The tolerance is irrelevant in this case.
+            );
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toBeNull();
+        })
+    });
+});

--- a/tests/Iso2768ToleranceStandardIdentifier.test.ts
+++ b/tests/Iso2768ToleranceStandardIdentifier.test.ts
@@ -87,4 +87,61 @@ describe('ISO 2768-1 Tolerance Standard Identifier', () => {
             });
         });
     });
+
+    const iso2768mTestGroups = [
+        {
+            // Dimensions that are the lowest in the nominal size range for medium tolerance.
+            type: 'Floor dimensions',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.1)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.1)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.3)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(0.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(0.8)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(1.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(2.0))
+            ]
+        },
+        {
+            // Dimensions that are the highest in the nominal size range for medium tolerance.
+            type: 'Ceiling dimensions',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.1)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.1)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(0.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(0.3)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(0.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(0.8)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(1.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4000), SymmetricalTolerance.fromMillimetres(2.0))
+            ]
+        },
+        {
+            // Tolerances that are just below the coarse tolerance class.
+            type: 'Ceiling tolerances',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1), SymmetricalTolerance.fromMillimetres(0.2 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(0.3 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(10), SymmetricalTolerance.fromMillimetres(0.5 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(50), SymmetricalTolerance.fromMillimetres(0.8 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(200), SymmetricalTolerance.fromMillimetres(1.2 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(800), SymmetricalTolerance.fromMillimetres(2.0 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(3.0 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3000), SymmetricalTolerance.fromMillimetres(4.0 - 0.01))
+            ]
+        }
+    ];
+
+    describe('ISO 2768-m tests', () => {
+        iso2768mTestGroups.forEach(group => {
+            describe(group.type, () => {
+                test.each(group.cases)(`should identify ISO 2768-m for %s`, (dimensionWithTolerance: DimensionWithTolerance) => {
+                        const result = identifier.identifyToleranceStandard(dimensionWithTolerance);
+                        expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+                    }
+                );
+            });
+        });
+    });
 });

--- a/tests/Iso2768ToleranceStandardIdentifier.test.ts
+++ b/tests/Iso2768ToleranceStandardIdentifier.test.ts
@@ -144,4 +144,61 @@ describe('ISO 2768-1 Tolerance Standard Identifier', () => {
             });
         });
     });
+
+    const iso2768cTestGroups = [
+        {
+            // Dimensions that are the lowest in the nominal size range.
+            type: 'Floor dimensions',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(0.3)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(7), SymmetricalTolerance.fromMillimetres(0.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(31), SymmetricalTolerance.fromMillimetres(0.8)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(121), SymmetricalTolerance.fromMillimetres(1.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(401), SymmetricalTolerance.fromMillimetres(2.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1001), SymmetricalTolerance.fromMillimetres(3.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2001), SymmetricalTolerance.fromMillimetres(4.0))
+            ]
+        },
+        {
+            // Dimensions that are the highest in the nominal size range.
+            type: 'Ceiling dimensions',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.3)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(0.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(0.8)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(1.2)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(2.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(3.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4000), SymmetricalTolerance.fromMillimetres(4.0))
+            ]
+        },
+        {
+            // Tolerances that are just below the very coarse tolerance class.
+            type: 'Ceiling tolerances',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1), SymmetricalTolerance.fromMillimetres(100.0)),  // There is no very coarse tolerance for 0.5 up to 3, so any tolerance above coarse will do.
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(0.5 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(10), SymmetricalTolerance.fromMillimetres(1.0 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(50), SymmetricalTolerance.fromMillimetres(1.5 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(200), SymmetricalTolerance.fromMillimetres(2.5 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(800), SymmetricalTolerance.fromMillimetres(4.0 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(6.0 - 0.01)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3000), SymmetricalTolerance.fromMillimetres(8.0 - 0.01))
+            ]
+        },
+    ];
+
+    describe('ISO 2768-c tests', () => {
+        iso2768cTestGroups.forEach(group => {
+            describe(group.type, () => {
+                test.each(group.cases)(`should identify ISO 2768-c for %s`, (dimensionWithTolerance: DimensionWithTolerance) => {
+                        const result = identifier.identifyToleranceStandard(dimensionWithTolerance);
+                        expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+                    }
+                );
+            });
+        });
+    });
 });

--- a/tests/Iso2768ToleranceStandardIdentifier.test.ts
+++ b/tests/Iso2768ToleranceStandardIdentifier.test.ts
@@ -2,6 +2,7 @@ import {Iso2768ToleranceStandardIdentifier} from "../src/Iso2768ToleranceStandar
 import {DimensionWithTolerance} from "../src/DimensionWithTolerance";
 import {Dimension} from "../src/Dimension";
 import {SymmetricalTolerance} from "../src/SymmetricalTolerance";
+import {DeviationTolerance} from "../src/DeviationTolerance";
 import {ToleranceStandard} from "../src/ToleranceStandard";
 import {Iso2768ToleranceStandard} from "../src/Iso2768ToleranceStandard";
 
@@ -9,252 +10,1922 @@ describe('ISO 2768-1 Tolerance Standard Identifier', () => {
 
     const identifier: Iso2768ToleranceStandardIdentifier = new Iso2768ToleranceStandardIdentifier();
 
+    // Use the tolerance table for linear dimensions in the ISO 2768-1:1989
+    // documentation as reference: docs/iso-2768-1-1989.md
+
     describe('With edge cases', () => {
         test('Should not identify a tolerance standard for a dimension less than the nominal range', () => {
             const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
-                Dimension.fromMillimetres(0.4),
-                SymmetricalTolerance.fromMillimetres(0.0)  // The tolerance is irrelevant in this case.
-            );
+                Dimension.fromMillimetres(0.4), SymmetricalTolerance.fromMillimetres(0.0));  // The tolerance is irrelevant in this case.
             const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
             expect(result).toBeNull();
         });
 
         test('Should not identify a tolerance standard for a dimension greater than the nominal range', () => {
             const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
-                Dimension.fromMillimetres(4001),
-                SymmetricalTolerance.fromMillimetres(0.0)  // The tolerance is irrelevant in this case.
-            );
+                Dimension.fromMillimetres(4001), SymmetricalTolerance.fromMillimetres(0.0));  // The tolerance is irrelevant in this case.
             const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
             expect(result).toBeNull();
         })
     });
 
-    // Use the tolerance table for linear dimensions in the ISO 2768-1:1989
-    // documentation as reference: docs/iso-2768-1-1989.md
-    const iso2768fTestGroups = [
-        {
-            // Dimensions that are the lowest in the nominal size range for fine tolerance.
-            type: 'Floor dimensions',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.05)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.05)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.1)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.15)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(0.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(0.3)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(0.5))
-                // No tolerance for fine for over 2000 up to 4000.
-            ]
-        },
-        {
-            // Dimensions that are the highest in the nominal size range for fine tolerance.
-            type: 'Ceiling dimensions',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.05)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.05)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(0.1)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(0.15)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(0.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(0.3)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(0.5))
-                // No tolerance for fine for over 2000 up to 4000.
-            ]
-        },
-        {
-            // Tolerances that are just below the medium tolerance class.
-            type: 'Ceiling tolerances',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1), SymmetricalTolerance.fromMillimetres(0.1 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(0.1 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(10), SymmetricalTolerance.fromMillimetres(0.2 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(50), SymmetricalTolerance.fromMillimetres(0.3 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(200), SymmetricalTolerance.fromMillimetres(0.5 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(800), SymmetricalTolerance.fromMillimetres(0.8 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(1.2 - 0.01))
-                // No tolerance for fine over 2000 up to 4000.
-            ]
-        }
-    ];
+    describe('Nominal size range from 0.5 mm up to 3 mm', () => {
 
-    describe('ISO 2768-f tests', () => {
-        iso2768fTestGroups.forEach(group => {
-            describe(group.type, () => {
-                test.each(group.cases)(`should identify ISO 2768-f for %s`, (dimensionWithTolerance: DimensionWithTolerance) => {
-                        const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimensionWithTolerance);
-                        expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
-                    }
-                );
+        describe('ISO 2768-f', () => {
+
+            test('Should identify \'fine\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.05));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
             });
+
+            test('Should identify \'fine\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.05));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.05, -0.05));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with wider symmetrical tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.09));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should identify \'fine\' for dimension with wider deviation tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.05, -0.06));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.01));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.01, -0.05));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.2, -0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+        });
+
+        describe('ISO 2768-m', () => {
+
+            test('Should identify \'medium\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, -0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with wider symmetrical tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should identify \'medium\' for dimension with wider deviation tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, -0.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.09));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.09, -0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.3, -0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+        });
+
+        describe('ISO 2768-c', () => {
+
+            test('Should identify \'coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.2, -0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with much wider symmetrical tolerance', () => {
+                // There is no 'very coarse' tolerance for this nominal size range.
+                // Therefore, there is no wider limit for this tolerance class.
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should identify \'coarse\' for dimension with much wider deviation tolerance', () => {
+                // There is no 'very coarse' tolerance for this nominal size range.
+                // Therefore, there is no wider limit for this tolerance class.
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.2, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(0.5), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.19, -0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+        });
+
+        // ISO 2768-v is not covered for this nominal size range.
+    });
+
+    describe('Nominal size range from over 3 mm up to 6 mm', () => {
+
+        describe('ISO 2768-f', () => {
+
+            test('Should identify \'fine\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.05));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.05));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.05, -0.05));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with wider symmetrical tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.09));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should identify \'fine\' for dimension with wider deviation tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.05, -0.06));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.01));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.01, -0.05));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.2, -0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+        });
+
+        describe('ISO 2768-m', () => {
+
+            test('Should identify \'medium\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, -0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with wider symmetrical tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.29));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should identify \'medium\' for dimension with wider deviation tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, -0.29));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.09));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.09, -0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.4, -0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+        });
+
+        describe('ISO 2768-c', () => {
+
+            test('Should identify \'coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.3, -0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with wider symmetrical tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should identify \'coarse\' for dimension with wider deviation tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.3, -0.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.29));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.29, -0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.6, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+        });
+
+        describe('ISO 2768-v', () => {
+
+            test('Should identify \'very coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.5, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with wider symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+
+            test('Should identify \'very coarse\' for dimension with wider deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.5, -0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.49, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
         });
     });
 
-    const iso2768mTestGroups = [
-        {
-            // Dimensions that are the lowest in the nominal size range for medium tolerance.
-            type: 'Floor dimensions',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.1)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.1)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.3)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(0.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(0.8)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(1.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(2.0))
-            ]
-        },
-        {
-            // Dimensions that are the highest in the nominal size range for medium tolerance.
-            type: 'Ceiling dimensions',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.1)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.1)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(0.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(0.3)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(0.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(0.8)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(1.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4000), SymmetricalTolerance.fromMillimetres(2.0))
-            ]
-        },
-        {
-            // Tolerances that are just below the coarse tolerance class.
-            type: 'Ceiling tolerances',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1), SymmetricalTolerance.fromMillimetres(0.2 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(0.3 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(10), SymmetricalTolerance.fromMillimetres(0.5 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(50), SymmetricalTolerance.fromMillimetres(0.8 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(200), SymmetricalTolerance.fromMillimetres(1.2 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(800), SymmetricalTolerance.fromMillimetres(2.0 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(3.0 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3000), SymmetricalTolerance.fromMillimetres(4.0 - 0.01))
-            ]
-        }
-    ];
+    describe('Nominal size range from over 6 mm up to 30 mm', () => {
 
-    describe('ISO 2768-m tests', () => {
-        iso2768mTestGroups.forEach(group => {
-            describe(group.type, () => {
-                test.each(group.cases)(`should identify ISO 2768-m for %s`, (dimensionWithTolerance: DimensionWithTolerance) => {
-                        const result = identifier.identifyToleranceStandard(dimensionWithTolerance);
-                        expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
-                    }
-                );
+        describe('ISO 2768-f', () => {
+
+            test('Should identify \'fine\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
             });
+
+            test('Should identify \'fine\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, -0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with wider symmetrical tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), SymmetricalTolerance.fromMillimetres(0.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should identify \'fine\' for dimension with wider deviation tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, -0.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.05));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.05, -0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.3, -0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+        });
+
+        describe('ISO 2768-m', () => {
+
+            test('Should identify \'medium\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.2, -0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with wider symmetrical tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), SymmetricalTolerance.fromMillimetres(0.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should identify \'medium\' for dimension with wider deviation tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.2, -0.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.19, -0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.6, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+        });
+
+        describe('ISO 2768-c', () => {
+
+            test('Should identify \'coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.5, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with wider symmetrical tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), SymmetricalTolerance.fromMillimetres(0.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should identify \'coarse\' for dimension with wider deviation tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.5, -0.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(1.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.49, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.2, -1.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+        });
+
+        describe('ISO 2768-v', () => {
+
+            test('Should identify \'very coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(1.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(1.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.0, -1.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with wider symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), SymmetricalTolerance.fromMillimetres(1.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+
+            test('Should identify \'very coarse\' for dimension with wider deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(15), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.0, -1.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(0.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(6.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.99, -1.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
         });
     });
 
-    const iso2768cTestGroups = [
-        {
-            // Dimensions that are the lowest in the nominal size range.
-            type: 'Floor dimensions',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(0.5), SymmetricalTolerance.fromMillimetres(0.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(0.3)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(7), SymmetricalTolerance.fromMillimetres(0.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(31), SymmetricalTolerance.fromMillimetres(0.8)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(121), SymmetricalTolerance.fromMillimetres(1.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(401), SymmetricalTolerance.fromMillimetres(2.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1001), SymmetricalTolerance.fromMillimetres(3.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2001), SymmetricalTolerance.fromMillimetres(4.0))
-            ]
-        },
-        {
-            // Dimensions that are the highest in the nominal size range.
-            type: 'Ceiling dimensions',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3), SymmetricalTolerance.fromMillimetres(0.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.3)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(0.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(0.8)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(1.2)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(2.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(3.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4000), SymmetricalTolerance.fromMillimetres(4.0))
-            ]
-        },
-        {
-            // Tolerances that are just below the very coarse tolerance class.
-            type: 'Ceiling tolerances',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1), SymmetricalTolerance.fromMillimetres(100.0)),  // There is no very coarse tolerance for 0.5 up to 3, so any tolerance above coarse will do.
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(0.5 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(10), SymmetricalTolerance.fromMillimetres(1.0 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(50), SymmetricalTolerance.fromMillimetres(1.5 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(200), SymmetricalTolerance.fromMillimetres(2.5 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(800), SymmetricalTolerance.fromMillimetres(4.0 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(6.0 - 0.01)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3000), SymmetricalTolerance.fromMillimetres(8.0 - 0.01))
-            ]
-        },
-    ];
+    describe('Nominal size range from over 30 mm up to 120 mm', () => {
 
-    describe('ISO 2768-c tests', () => {
-        iso2768cTestGroups.forEach(group => {
-            describe(group.type, () => {
-                test.each(group.cases)(`should identify ISO 2768-c for %s`, (dimensionWithTolerance: DimensionWithTolerance) => {
-                        const result = identifier.identifyToleranceStandard(dimensionWithTolerance);
-                        expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
-                    }
-                );
+        describe('ISO 2768-f', () => {
+
+            test('Should identify \'fine\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.15));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
             });
+
+            test('Should identify \'fine\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(0.15));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.15, -0.15));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with wider symmetrical tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), SymmetricalTolerance.fromMillimetres(0.29));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should identify \'fine\' for dimension with wider deviation tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.15, -0.29));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.1));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.1, -0.15));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.4, -0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+        });
+
+        describe('ISO 2768-m', () => {
+
+            test('Should identify \'medium\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.3, -0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with wider symmetrical tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), SymmetricalTolerance.fromMillimetres(0.79));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should identify \'medium\' for dimension with wider deviation tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.3, -0.79));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.29));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.29, -0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.9, -0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+        });
+
+        describe('ISO 2768-c', () => {
+
+            test('Should identify \'coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.8, -0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with wider symmetrical tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), SymmetricalTolerance.fromMillimetres(1.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should identify \'coarse\' for dimension with wider deviation tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.8, -1.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(0.79));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(1.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.79, -0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.8, -1.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+        });
+
+        describe('ISO 2768-v', () => {
+
+            test('Should identify \'very coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(1.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(1.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.5, -1.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with wider symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), SymmetricalTolerance.fromMillimetres(2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+
+            test('Should identify \'very coarse\' for dimension with wider deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(60), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.5, -2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(1.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(30.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.49, -1.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
         });
     });
 
-    const iso2768vTestGroups = [
-        {
-            // Dimensions that are the lowest in the nominal size range for very coarse tolerance.
-            type: 'Floor dimensions',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(1.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(1.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(2.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(4.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(6.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(8.0))
-            ]
-        },
-        {
-            // Dimensions that are the highest in the nominal size range for very coarse tolerance.
-            type: 'Ceiling dimensions',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(1.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(1.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(2.5)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(4.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(6.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4000), SymmetricalTolerance.fromMillimetres(8.0))
-            ]
-        },
-        {
-            // Tolerances that are above the very coarse tolerance class. Since there isn't a following tolerance class,
-            // this tolerance class covers any greater tolerance. The tolerance of 100.0 mm is used in every nominal
-            // size range as an example.
-            type: 'Ceiling tolerances',
-            cases: [
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(100.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(10), SymmetricalTolerance.fromMillimetres(100.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(50), SymmetricalTolerance.fromMillimetres(100.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(200), SymmetricalTolerance.fromMillimetres(100.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(800), SymmetricalTolerance.fromMillimetres(100.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(100.0)),
-                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3000), SymmetricalTolerance.fromMillimetres(100.0))
-            ]
-        }
-    ];
+    describe('Nominal size range from over 120 mm up to 400 mm', () => {
 
-    describe('ISO 2768-v tests', () => {
-        iso2768vTestGroups.forEach(group => {
-            describe(group.type, () => {
-                test.each(group.cases)(`should identify ISO 2768-v for %s`, (dimensionWithTolerance: DimensionWithTolerance) => {
-                        const result = identifier.identifyToleranceStandard(dimensionWithTolerance);
-                        expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
-                    }
-                );
+        describe('ISO 2768-f', () => {
+
+            test('Should identify \'fine\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
             });
+
+            test('Should identify \'fine\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.2, -0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with wider symmetrical tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), SymmetricalTolerance.fromMillimetres(0.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should identify \'fine\' for dimension with wider deviation tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.2, -0.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(0.15));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.15, -0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.6, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+        });
+
+        describe('ISO 2768-m', () => {
+
+            test('Should identify \'medium\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.5, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with wider symmetrical tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), SymmetricalTolerance.fromMillimetres(1.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should identify \'medium\' for dimension with wider deviation tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.5, -1.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(0.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.49, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.5, -1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+        });
+
+        describe('ISO 2768-c', () => {
+
+            test('Should identify \'coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.2, -1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with wider symmetrical tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), SymmetricalTolerance.fromMillimetres(2.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should identify \'coarse\' for dimension with wider deviation tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.2, -2.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(1.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(2.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.19, -1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(3.0, -2.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+        });
+
+        describe('ISO 2768-v', () => {
+
+            test('Should identify \'very coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(2.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(2.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(2.5, -2.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with wider symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), SymmetricalTolerance.fromMillimetres(3.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+
+            test('Should identify \'very coarse\' for dimension with wider deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(250), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(2.5, -3.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(2.49));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(120.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(2.49, -2.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+        });
+    });
+
+    describe('Nominal size range from over 400 mm up to 1000 mm', () => {
+
+        describe('ISO 2768-f', () => {
+
+            test('Should identify \'fine\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.3, -0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with wider symmetrical tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), SymmetricalTolerance.fromMillimetres(0.79));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should identify \'fine\' for dimension with wider deviation tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.3, -0.79));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(0.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.2, -0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.0, -0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+        });
+
+        describe('ISO 2768-m', () => {
+
+            test('Should identify \'medium\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.8, -0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with wider symmetrical tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), SymmetricalTolerance.fromMillimetres(1.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should identify \'medium\' for dimension with wider deviation tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.8, -1.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(0.79));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.79, -0.8));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(2.5, -2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+        });
+
+        describe('ISO 2768-c', () => {
+
+            test('Should identify \'coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(2.0, -2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with wider symmetrical tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), SymmetricalTolerance.fromMillimetres(3.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should identify \'coarse\' for dimension with wider deviation tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(2.0, -3.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(1.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.99, -2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(5.0, -4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+        });
+
+        describe('ISO 2768-v', () => {
+
+            test('Should identify \'very coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(4.0, -4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with wider symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), SymmetricalTolerance.fromMillimetres(5.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+
+            test('Should identify \'very coarse\' for dimension with wider deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(700), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(4.0, -5.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(3.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(400.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(3.99, -4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+        });
+    });
+
+    describe('Nominal size range from over 1000 mm up to 2000 mm', () => {
+
+        describe('ISO 2768-f', () => {
+
+            test('Should identify \'fine\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.5, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should identify \'fine\' for dimension with wider symmetrical tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(1.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should identify \'fine\' for dimension with wider deviation tolerance narrower than \'medium\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.5, -1.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(0.3));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+
+            test('Should not identify \'fine\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(0.3, -0.5));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            })
+
+            test('Should not identify \'fine\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.5, -1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+            });
+        });
+
+        describe('ISO 2768-m', () => {
+
+            test('Should identify \'medium\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.2, -1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with wider symmetrical tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(2.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should identify \'medium\' for dimension with wider deviation tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.2, -2.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(1.19));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(3.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.19, -1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(3.5, -3.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+        });
+
+        describe('ISO 2768-c', () => {
+
+            test('Should identify \'coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(3.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(3.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(3.0, -3.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with wider symmetrical tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(5.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should identify \'coarse\' for dimension with wider deviation tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(3.0, -5.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(2.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(6.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(2.99, -3.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(7.0, -6.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+        });
+
+        describe('ISO 2768-v', () => {
+
+            test('Should identify \'very coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(6.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(6.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(6.0, -6.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with wider symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(7.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+
+            test('Should identify \'very coarse\' for dimension with wider deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1500), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(6.0, -7.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(5.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(1000.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(5.99, -6.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+        });
+    });
+
+    describe('Nominal size range from over 2000 mm up to 4000 mm', () => {
+
+        // ISO 2768-f is not covered for this nominal size range.
+
+        describe('ISO 2768-m', () => {
+
+            test('Should identify \'medium\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(4000), SymmetricalTolerance.fromMillimetres(2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(2.0, -2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should identify \'medium\' for dimension with wider symmetrical tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), SymmetricalTolerance.fromMillimetres(3.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should identify \'medium\' for dimension with wider deviation tolerance narrower than \'coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(2.0, -3.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(1.2));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+
+            test('Should not identify \'medium\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(1.2, -2.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            })
+
+            test('Should not identify \'medium\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(5.0, -4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+            });
+        });
+
+        describe('ISO 2768-c', () => {
+
+            test('Should identify \'coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(4000), SymmetricalTolerance.fromMillimetres(4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(4.0, -4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should identify \'coarse\' for dimension with wider symmetrical tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), SymmetricalTolerance.fromMillimetres(7.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should identify \'coarse\' for dimension with wider deviation tolerance narrower than \'very coarse\'', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(4.0, -7.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(3.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+
+            test('Should not identify \'coarse\' for dimension with too wide symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(8.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(3.99, -4.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            })
+
+            test('Should not identify \'coarse\' for dimension with too wide deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(10.0, -8.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+            });
+        });
+
+        describe('ISO 2768-v', () => {
+
+            test('Should identify \'very coarse\' for floor dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(8.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for ceiling dimension with exact symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(4000), SymmetricalTolerance.fromMillimetres(8.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with exact deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(8.0, -8.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should identify \'very coarse\' for dimension with wider symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), SymmetricalTolerance.fromMillimetres(10.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
+
+            test('Should identify \'very coarse\' for dimension with wider deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(3000), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(8.0, -10.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight symmetrical tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(7.99));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            });
+
+            test('Should not identify \'very coarse\' for dimension with too tight deviation tolerance', () => {
+                const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                    Dimension.fromMillimetres(2000.01), DeviationTolerance.fromUpperAndLowerBoundsInMillimetres(7.99, -8.0));
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+                expect(result).not.toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+            })
         });
     });
 });

--- a/tests/Iso2768ToleranceStandardIdentifier.test.ts
+++ b/tests/Iso2768ToleranceStandardIdentifier.test.ts
@@ -29,6 +29,20 @@ describe('ISO 2768-1 Tolerance Standard Identifier', () => {
         })
     });
 
+    // The tests cover for each nominal size range and their tolerance classes:
+    // - Floor and ceiling dimensions
+    // - Dimensions with exact symmetrical and deviation tolerances
+    // - Dimensions with wider tolerances that are narrower than the next class
+    // - Dimensions with too tight tolerances
+    // - Dimensions with too wide tolerances
+    //
+    // Not all tolerance classes are covered by the nominal size ranges.
+
+    // I gave it a try to parameterize the tests, but I couldn't come up with a
+    // clear solution. They became either too complex or deeply nested and
+    // hard to read. Nevertheless, I think that it might be possible, but
+    // that'll be a challenge for the future.
+
     describe('Nominal size range from 0.5 mm up to 3 mm', () => {
 
         describe('ISO 2768-f', () => {

--- a/tests/Iso2768ToleranceStandardIdentifier.test.ts
+++ b/tests/Iso2768ToleranceStandardIdentifier.test.ts
@@ -201,4 +201,60 @@ describe('ISO 2768-1 Tolerance Standard Identifier', () => {
             });
         });
     });
+
+    const iso2768vTestGroups = [
+        {
+            // Dimensions that are the lowest in the nominal size range for very coarse tolerance.
+            type: 'Floor dimensions',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3.01), SymmetricalTolerance.fromMillimetres(0.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6.01), SymmetricalTolerance.fromMillimetres(1.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30.01), SymmetricalTolerance.fromMillimetres(1.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120.01), SymmetricalTolerance.fromMillimetres(2.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400.01), SymmetricalTolerance.fromMillimetres(4.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000.01), SymmetricalTolerance.fromMillimetres(6.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000.01), SymmetricalTolerance.fromMillimetres(8.0))
+            ]
+        },
+        {
+            // Dimensions that are the highest in the nominal size range for very coarse tolerance.
+            type: 'Ceiling dimensions',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(6), SymmetricalTolerance.fromMillimetres(0.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(30), SymmetricalTolerance.fromMillimetres(1.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(120), SymmetricalTolerance.fromMillimetres(1.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(400), SymmetricalTolerance.fromMillimetres(2.5)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1000), SymmetricalTolerance.fromMillimetres(4.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(2000), SymmetricalTolerance.fromMillimetres(6.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4000), SymmetricalTolerance.fromMillimetres(8.0))
+            ]
+        },
+        {
+            // Tolerances that are above the very coarse tolerance class. Since there isn't a following tolerance class,
+            // this tolerance class covers any greater tolerance. The tolerance of 100.0 mm is used in every nominal
+            // size range as an example.
+            type: 'Ceiling tolerances',
+            cases: [
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(4), SymmetricalTolerance.fromMillimetres(100.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(10), SymmetricalTolerance.fromMillimetres(100.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(50), SymmetricalTolerance.fromMillimetres(100.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(200), SymmetricalTolerance.fromMillimetres(100.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(800), SymmetricalTolerance.fromMillimetres(100.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(1500), SymmetricalTolerance.fromMillimetres(100.0)),
+                DimensionWithTolerance.fromDimensionAndTolerance(Dimension.fromMillimetres(3000), SymmetricalTolerance.fromMillimetres(100.0))
+            ]
+        }
+    ];
+
+    describe('ISO 2768-v tests', () => {
+        iso2768vTestGroups.forEach(group => {
+            describe(group.type, () => {
+                test.each(group.cases)(`should identify ISO 2768-v for %s`, (dimensionWithTolerance: DimensionWithTolerance) => {
+                        const result = identifier.identifyToleranceStandard(dimensionWithTolerance);
+                        expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+                    }
+                );
+            });
+        });
+    });
 });

--- a/tests/SymmetricalTolerance.test.ts
+++ b/tests/SymmetricalTolerance.test.ts
@@ -1,0 +1,35 @@
+import {SymmetricalTolerance} from "../src/SymmetricalTolerance";
+
+describe('Symmetrical Tolerance', () => {
+
+    describe('When constructing with factory method', () => {
+
+        describe('With valid inputs', () => {
+            [2.5, 1.0, 0.0, -1.0, -2.5].forEach(mm => {
+                test(`Should return upper and lower bounds as ${Math.abs(mm)} and -${Math.abs(mm)} for ${mm} mm`, () => {
+                    const tolerance = SymmetricalTolerance.fromMillimetres(mm);
+                    expect(tolerance.getUpper()).toBe(Math.abs(mm));
+                    expect(tolerance.getLower()).toBe(-Math.abs(mm));
+                });
+            });
+        });
+
+        describe('With edge cases', () => {
+            [Number.MAX_VALUE, Number.MIN_VALUE, 1e-10].forEach(mm => {
+                test(`Should handle edge case ${mm} mm correctly`, () => {
+                    const tolerance = SymmetricalTolerance.fromMillimetres(mm);
+                    expect(tolerance.getUpper()).toBe(Math.abs(mm));
+                    expect(tolerance.getLower()).toBe(-Math.abs(mm));
+                });
+            });
+        });
+
+        describe('With invalid inputs', () => {
+            [NaN, Infinity, -Infinity].forEach(mm => {
+                test(`Should throw an error for invalid input ${mm}`, () => {
+                    expect(() => SymmetricalTolerance.fromMillimetres(mm)).toThrow();
+                });
+            });
+        });
+    });
+});

--- a/tests/ToleranceCoverageChecker.test.ts
+++ b/tests/ToleranceCoverageChecker.test.ts
@@ -1,0 +1,25 @@
+import {SymmetricalTolerance} from "../src/SymmetricalTolerance";
+import {ToleranceCoverageChecker} from "../src/ToleranceCoverageChecker";
+
+describe('ToleranceCoverageChecker', () => {
+
+    test('Should cover a symmetrical tolerance equal to itself', () => {
+        const tolerance = SymmetricalTolerance.fromMillimetres(0.1);
+        const result = ToleranceCoverageChecker.isToleranceCovered(tolerance, tolerance);
+        expect(result).toBe(true);
+    });
+
+    test('Should cover a wider symmetrical tolerance', () => {
+        const candidate = SymmetricalTolerance.fromMillimetres(0.2);
+        const cover = SymmetricalTolerance.fromMillimetres(0.1);
+        const result = ToleranceCoverageChecker.isToleranceCovered(candidate, cover);
+        expect(result).toBe(true);
+    });
+
+    test('Should not cover a narrower symmetrical tolerance', () => {
+        const candidate = SymmetricalTolerance.fromMillimetres(0.1);
+        const cover = SymmetricalTolerance.fromMillimetres(0.2);
+        const result = ToleranceCoverageChecker.isToleranceCovered(candidate, cover);
+        expect(result).toBe(false);
+    });
+});


### PR DESCRIPTION
This pull request introduces the implementation of tolerance standard identification. 

The identification for the tolerance standard ISO 2768-1:1989 is implemented and includes test coverage for related classes and functionality.

Documentation for ISO 286-1:2010 is included, but the implementation has not been made.

A user interface is not included in this pull request. Only the necessary backend code for its later integration.