### PR TITLE
Add chained ISO 2768 and ISO 286 tolerance standard identifier

### DIFF
--- a/src/ChainedToleranceStandardIdentifier.ts
+++ b/src/ChainedToleranceStandardIdentifier.ts
@@ -1,0 +1,57 @@
+import {ToleranceStandardIdentifier} from "./ToleranceStandardIdentifier";
+import {DimensionWithTolerance} from "./DimensionWithTolerance";
+import {ToleranceStandard} from "./ToleranceStandard";
+
+/**
+ * A tolerance standard identifier that chains identifiers together. The order
+ * of priority follows the order they were provided in the constructor. This
+ * design follows the Chain of Responsibility pattern.
+ *
+ * The first identifier in the chain that can identify a tolerance standard
+ * will return it, otherwise it will return null.
+ */
+export class ChainedToleranceStandardIdentifier implements ToleranceStandardIdentifier {
+
+    /**
+     * Creates a new instance of the ChainedToleranceStandardIdentifier with
+     * the tolerance standard identifiers.
+     *
+     * Private constructor to enforce the use of the static factory method.
+     *
+     * @param identifiers the array of identifiers to chain together.
+     */
+    private constructor(private readonly identifiers: ReadonlyArray<ToleranceStandardIdentifier>) {
+        // The field is assigned via a parameter property.
+    }
+
+    /**
+     * Static factory method to create a new instance of the
+     * ChainedToleranceStandardIdentifier with the provided identifiers. The
+     * order of the identifiers determines the order of priority for
+     * identification. The priority is "first come, first served".
+     *
+     * @param identifiers the array of identifiers to chain together.
+     * @returns a new instance of ChainedToleranceStandardIdentifier.
+     */
+    static fromIdentifiers(identifiers: ReadonlyArray<ToleranceStandardIdentifier> = []): ChainedToleranceStandardIdentifier {
+        return new ChainedToleranceStandardIdentifier(identifiers);
+    }
+
+    /**
+     * Identifies the tolerance standard for the dimension with tolerance using
+     * the chained identifiers. The first identifier that can identify a
+     * tolerance standard will return it, otherwise it will return null.
+     *
+     * @param dimensionWithTolerance the dimension with its associated tolerance to be identified.
+     * @returns the identified tolerance standard or null if none could be identified.
+     */
+    identifyToleranceStandard(dimensionWithTolerance: DimensionWithTolerance): ToleranceStandard | null {
+        for (const identifier of this.identifiers) {
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimensionWithTolerance);
+            if (result !== null) {
+                return result;  // Return the first identified tolerance standard.
+            }
+        }
+        return null;  // Otherwise, if no identifier found a match, return null.
+    }
+}

--- a/src/ToleranceStandardIdentifierFactory.ts
+++ b/src/ToleranceStandardIdentifierFactory.ts
@@ -1,0 +1,24 @@
+import {ChainedToleranceStandardIdentifier} from "./ChainedToleranceStandardIdentifier";
+import {Iso2768ToleranceStandardIdentifier} from "./Iso2768ToleranceStandardIdentifier";
+import {Iso286ToleranceStandardIdentifier} from "./Iso286ToleranceStandardIdentifier";
+
+/**
+ * Factory class for creating tolerance standard identifiers.
+ */
+export class ToleranceStandardIdentifierFactory {
+
+    /**
+     * Creates a chained tolerance standard identifier that combines ISO 2768
+     * and ISO 286. This identifier can be used to identify tolerances based on
+     * both standards where ISO 2768 takes precedence and ISO 286 acts as a
+     * fallback.
+     *
+     * @returns The chained identifier for ISO 2768 and ISO 286.
+     */
+    static createChainedIso2768AndIso286Identifier(): ChainedToleranceStandardIdentifier {
+        return ChainedToleranceStandardIdentifier.fromIdentifiers([
+            new Iso2768ToleranceStandardIdentifier(),
+            new Iso286ToleranceStandardIdentifier()
+        ]);
+    }
+}

--- a/tests/ChainedIso2768AndIso286ToleranceStandardIdentifier.test.ts
+++ b/tests/ChainedIso2768AndIso286ToleranceStandardIdentifier.test.ts
@@ -1,0 +1,109 @@
+import {ToleranceStandardIdentifierFactory} from "../src/ToleranceStandardIdentifierFactory";
+import {ToleranceStandardIdentifier} from "../src/ToleranceStandardIdentifier";
+import {DimensionWithTolerance} from "../src/DimensionWithTolerance";
+import {Dimension} from "../src/Dimension";
+import {SymmetricalTolerance} from "../src/SymmetricalTolerance";
+import {ToleranceStandard} from "../src/ToleranceStandard";
+import {Iso2768ToleranceStandard} from "../src/Iso2768ToleranceStandard";
+import {Iso286ToleranceStandard} from "../src/Iso286ToleranceStandard";
+import {DeviationTolerance} from "../src/DeviationTolerance";
+
+// The chained ISO 2768 and ISO 286 tolerance standard identifier is
+// constructed with the ToleranceStandardIdentifierFactory and is not
+// a class on its own.
+
+describe('ChainedIso2768AndIso286ToleranceStandardIdentifier', () => {
+
+    const identifier: ToleranceStandardIdentifier = ToleranceStandardIdentifierFactory.createChainedIso2768AndIso286Identifier();
+
+    // ISO 2768 lower nominal size limit is 0.5 mm.
+    // ISO 286 lower nominal size limit is above 0 mm.
+    test('Should not identify tolerance standard for dimension less than ISO 2768 and ISO 286 nominal size', () => {
+        const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+            Dimension.fromMillimetres(0.0), DeviationTolerance.fromUpperAndLowerBoundsInMicrometres(18, 0));
+        const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+        expect(result).toBeNull();
+    });
+
+    // ISO 2768 upper nominal size limit is 4000 mm.
+    // ISO 286 upper nominal size limit is 3150 mm.
+    test('Should not identify tolerance standard for dimension greater than ISO 2768 and ISO 286 nominal size', () => {
+        const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+            Dimension.fromMillimetres(4000.1), SymmetricalTolerance.fromMillimetres(8.0));
+        const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+        expect(result).toBeNull();
+    });
+
+    describe('When identifying tolerance standard for 12 mm with varying tolerances', () => {
+
+        test('Should identify ISO 2768 v for tolerance ±1.0 mm', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), SymmetricalTolerance.fromMillimetres(1.0));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('v'));
+        });
+
+        test('Should identify ISO 2768 c for tolerance ±0.5 mm', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), SymmetricalTolerance.fromMillimetres(0.5));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('c'));
+        });
+
+        test('Should identify ISO 2768 m for tolerance ±0.2 mm', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), SymmetricalTolerance.fromMillimetres(0.2));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('m'));
+        });
+
+        test('Should identify ISO 2768 f for tolerance ±0.1 mm', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), SymmetricalTolerance.fromMillimetres(0.1));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toStrictEqual(Iso2768ToleranceStandard.fromToleranceClass('f'));
+        });
+
+        test('Should identify ISO 286 IT10 for tolerance +70/-0 um', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), DeviationTolerance.fromUpperAndLowerBoundsInMicrometres(70, 0));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toStrictEqual(Iso286ToleranceStandard.fromToleranceGrade('IT10'));
+        });
+
+        test('Should identify ISO 286 IT9 for tolerance +43/-0 um', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), DeviationTolerance.fromUpperAndLowerBoundsInMicrometres(43, 0));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toStrictEqual(Iso286ToleranceStandard.fromToleranceGrade('IT9'));
+        });
+
+        test('Should identify ISO 286 IT8 for tolerance +27/-0 um', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), DeviationTolerance.fromUpperAndLowerBoundsInMicrometres(27, 0));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toStrictEqual(Iso286ToleranceStandard.fromToleranceGrade('IT8'));
+        });
+
+        test('Should identify ISO 286 IT7 for tolerance +18/-0 um', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), DeviationTolerance.fromUpperAndLowerBoundsInMicrometres(18, 0));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toStrictEqual(Iso286ToleranceStandard.fromToleranceGrade('IT7'));
+        });
+
+        test('Should identify ISO 286 IT6 for tolerance +11/-0 um', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), DeviationTolerance.fromUpperAndLowerBoundsInMicrometres(11, 0));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toStrictEqual(Iso286ToleranceStandard.fromToleranceGrade('IT6'));
+        });
+
+        test('Should not identify tolerance standard when tolerance is too narrow', () => {
+            const dimension: DimensionWithTolerance = DimensionWithTolerance.fromDimensionAndTolerance(
+                Dimension.fromMillimetres(12.0), DeviationTolerance.fromUpperAndLowerBoundsInMicrometres(7, 0));
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard(dimension);
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/tests/ChainedToleranceStandardIdentifier.test.ts
+++ b/tests/ChainedToleranceStandardIdentifier.test.ts
@@ -1,0 +1,107 @@
+import {ChainedToleranceStandardIdentifier} from "../src/ChainedToleranceStandardIdentifier";
+import {DimensionWithTolerance} from "../src/DimensionWithTolerance";
+import {ToleranceStandardIdentifier} from "../src/ToleranceStandardIdentifier";
+import {ToleranceStandard} from "../src/ToleranceStandard";
+
+describe("ChainedToleranceStandardIdentifier", () => {
+
+    test('Should not identify tolerance standard when no identifiers are provided', () => {
+        const identifier: ToleranceStandardIdentifier = ChainedToleranceStandardIdentifier.fromIdentifiers();
+        const result: ToleranceStandard | null = identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+        expect(result).toBeNull();
+    });
+
+    test('Should not identify tolerance standard when empty array is provided', () => {
+        const identifier: ToleranceStandardIdentifier = ChainedToleranceStandardIdentifier.fromIdentifiers([]);
+        const result: ToleranceStandard | null = identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+        expect(result).toBeNull();
+    });
+
+    describe('When providing a single identifier', () => {
+
+        test('Should not identify tolerance standard when identifier returns null', () => {
+            const mockIdentifier: ToleranceStandardIdentifier = {
+                identifyToleranceStandard: jest.fn().mockReturnValue(null)
+            };
+            const identifier: ToleranceStandardIdentifier = ChainedToleranceStandardIdentifier.fromIdentifiers([mockIdentifier]);
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+            expect(result).toBeNull();
+        });
+
+        test('Should identify tolerance standard when identifier returns tolerance standard', () => {
+            const mockIdentifier: ToleranceStandardIdentifier = {
+                identifyToleranceStandard: jest.fn().mockReturnValue({name: 'ISO 2768'})
+            };
+            const identifier: ToleranceStandardIdentifier = ChainedToleranceStandardIdentifier.fromIdentifiers([mockIdentifier]);
+            const result: ToleranceStandard | null = identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+            expect(result).toStrictEqual({name: 'ISO 2768'});
+        });
+    });
+
+    describe('When chaining multiple identifiers', () => {
+
+        describe('And all return null', () => {
+
+            const mockIdentifierNull: ToleranceStandardIdentifier = {
+                identifyToleranceStandard: jest.fn().mockReturnValue(null)
+            };
+            const identifier: ToleranceStandardIdentifier = ChainedToleranceStandardIdentifier.fromIdentifiers([
+                mockIdentifierNull, mockIdentifierNull, mockIdentifierNull
+            ]);
+
+            beforeEach(() => {
+               jest.clearAllMocks();
+            });
+
+            test('Should not identify tolerance standard', () => {
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+                expect(result).toBeNull();
+            });
+
+            test('Should call each identifier in the chain', () => {
+                identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+                expect(mockIdentifierNull.identifyToleranceStandard).toHaveBeenCalledTimes(3);
+            });
+        });
+
+        describe('And one returns null, others return tolerance standards', () => {
+
+            const mockIdentifierNull: ToleranceStandardIdentifier = {
+                identifyToleranceStandard: jest.fn().mockReturnValue(null)
+            };
+            const mockIdentifierIso2768: ToleranceStandardIdentifier = {
+                identifyToleranceStandard: jest.fn().mockReturnValue({name: 'ISO 2768'})
+            };
+            const mockIdentifierIso286: ToleranceStandardIdentifier = {
+                identifyToleranceStandard: jest.fn().mockReturnValue({name: 'ISO 286'})
+            };
+            const identifier: ToleranceStandardIdentifier = ChainedToleranceStandardIdentifier.fromIdentifiers([
+                mockIdentifierNull, mockIdentifierIso2768, mockIdentifierIso286
+            ]);
+
+            beforeEach(() => {
+                jest.clearAllMocks();
+            });
+
+            test('Should return first non-null tolerance standard', () => {
+                const result: ToleranceStandard | null = identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+                expect(result).toStrictEqual({name: 'ISO 2768'});
+            });
+
+            test('Should call prior identifiers before identifying tolerance standard', () => {
+                identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+                expect(mockIdentifierNull.identifyToleranceStandard).toHaveBeenCalled();
+            });
+
+            test('Should call identifier that first identifies tolerance standard', () => {
+                identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+                expect(mockIdentifierIso2768.identifyToleranceStandard).toHaveBeenCalled();
+            });
+
+            test('Should not call subsequent identifiers after identifying tolerance standard', () => {
+                identifier.identifyToleranceStandard({} as DimensionWithTolerance);
+                expect(mockIdentifierIso286.identifyToleranceStandard).not.toHaveBeenCalled();
+            });
+        });
+    });
+});


### PR DESCRIPTION
This pull request introduces support for creating chained tolerance standard identifiers and specifically implements one that chains ISO 2768 and ISO 286.

#### Key Changes:
- Added `ToleranceStandardIdentifierFactory` to create identifiers and a factory method for creating the chained ISO 2768 and ISO 286 identifier.
- Implemented `ChainedToleranceStandardIdentifier` for chaining multiple identifiers.
- Included unit tests covering edge cases, general identification precedence when chaining, and specific ISO 2768 and ISO 286 identification.